### PR TITLE
Add CI workflow to run tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,25 @@
+name: macOS Tests
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  build-and-test:
+    runs-on: macos-14
+    steps:
+      - uses: actions/checkout@v4
+      - name: Select Xcode 16
+        uses: maxim-lobanov/setup-xcode@v1
+        with:
+          xcode-version: "16.0"
+      - name: Install xcpretty
+        run: gem install xcpretty
+      - name: Run unit tests
+        run: |
+          set -o pipefail
+          xcodebuild -project DevTools.xcodeproj -scheme DevTools -destination 'platform=macOS' test | xcpretty
+        env:
+          NSUnbufferedIO: YES
+


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow to run tests on macOS when changes are pushed to `main`
- install `xcpretty` so the test step works on GitHub Actions
- ensure CI fails if `xcodebuild` fails by enabling `pipefail`
- select Xcode 16 so the project can be built

## Testing
- `swift test --parallel` *(fails: no tests found)*
- `swift test -l` *(fails: no tests found)*

------
https://chatgpt.com/codex/tasks/task_e_686652e80e3c832bb757400f4a7ba355