### PR TITLE
Implement real-time JSON formatter tool

### DIFF
--- a/DevTools/Core/Models/DevTool.swift
+++ b/DevTools/Core/Models/DevTool.swift
@@ -78,14 +78,6 @@ struct ToolRegistry: Sendable {
             category: .dateTime,
             route: .dateConverter
         ),
-        ToolDefinition(
-            id: "json-formatter",
-            name: "JSON Formatter",
-            icon: "curlybraces",
-            description: "Format, minify, and validate JSON data",
-            category: .formatting,
-            route: .jsonFormatter
-        )
     ]
     
     /// New ToolProvider-based tools (thread-safe with actor isolation)
@@ -116,6 +108,7 @@ struct ToolRegistry: Sendable {
             // Add new ToolProvider tools here:
             Base64EncoderTool.self,
             MarkdownPreviewTool.self,
+            JSONFormatterTool.self,
             // ExampleTool.self,
             // ColorPickerTool.self,
         ])

--- a/DevTools/Tools/JSONFormatterTool.swift
+++ b/DevTools/Tools/JSONFormatterTool.swift
@@ -1,0 +1,97 @@
+import SwiftUI
+
+/// Tool for formatting JSON data in real time
+struct JSONFormatterTool: ToolProvider {
+    static let metadata = ToolMetadata(
+        id: "json-formatter",
+        name: "JSON Formatter",
+        description: "Format and validate JSON data in real time",
+        icon: "curlybraces.square",
+        category: .formatting
+    )
+
+    @MainActor
+    static func createView() -> JSONFormatterView {
+        JSONFormatterView()
+    }
+}
+
+struct JSONFormatterView: View {
+    @State private var inputText: String = ""
+    @State private var formattedText: String = ""
+
+    var body: some View {
+        HSplitView {
+            inputEditor
+            outputEditor
+        }
+        .onAppear { formatInput() }
+        .navigationTitle(JSONFormatterTool.metadata.name)
+    }
+
+    private var inputEditor: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            HStack {
+                Text("JSON Input")
+                    .font(.headline)
+                Spacer()
+            }
+            .padding()
+
+            Divider()
+
+            TextEditor(text: $inputText)
+                .font(.system(.body, design: .monospaced))
+                .padding()
+                .background(Color(nsColor: .textBackgroundColor))
+                .onChange(of: inputText) { _, _ in
+                    formatInput()
+                }
+        }
+    }
+
+    private var outputEditor: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            HStack {
+                Text("Formatted JSON")
+                    .font(.headline)
+                Spacer()
+            }
+            .padding()
+
+            Divider()
+
+            TextEditor(text: .constant(formattedText))
+                .font(.system(.body, design: .monospaced))
+                .padding()
+                .background(Color(nsColor: .textBackgroundColor))
+                .disabled(true)
+        }
+    }
+
+    private func formatInput() {
+        formattedText = JSONFormatterTool.format(jsonString: inputText)
+    }
+}
+
+extension JSONFormatterTool {
+    /// Format a JSON string into pretty printed form
+    /// - Parameter jsonString: raw JSON string
+    /// - Returns: formatted JSON or error message
+    static func format(jsonString: String) -> String {
+        let data = Data(jsonString.utf8)
+        do {
+            let jsonObject = try JSONSerialization.jsonObject(with: data, options: [])
+            let prettyData = try JSONSerialization.data(withJSONObject: jsonObject, options: [.prettyPrinted])
+            return String(decoding: prettyData, as: UTF8.self)
+        } catch {
+            return "Invalid JSON"
+        }
+    }
+}
+
+#Preview {
+    NavigationStack {
+        JSONFormatterView()
+    }
+}


### PR DESCRIPTION
## Summary
- add a new `JSONFormatterTool`
- register the tool in `ToolRegistry`
- remove old legacy JSON Formatter entry

## Testing
- `swift build`
- `swift test -v` *(fails: no tests found)*

------
https://chatgpt.com/codex/tasks/task_e_6866adbbf5a4832bad948a5dba582834