### PR TITLE
Add paste image support to QR code tool

### DIFF
--- a/DevTools/Core/Services/ClipboardService.swift
+++ b/DevTools/Core/Services/ClipboardService.swift
@@ -38,6 +38,16 @@ final class ClipboardService: Sendable {
         }
         return url
     }
+
+    /// Get image from clipboard
+    /// - Returns: NSImage or nil if not available
+    func getImage() -> NSImage? {
+        let classes = [NSImage.self]
+        if let images = pasteboard.readObjects(forClasses: classes, options: nil) as? [NSImage] {
+            return images.first
+        }
+        return nil
+    }
     
     /// Get file URLs from clipboard (for drag & drop support)
     /// - Returns: Array of file URLs

--- a/DevTools/Tools/QRCodeTool.swift
+++ b/DevTools/Tools/QRCodeTool.swift
@@ -173,7 +173,7 @@ struct QRCodeToolView: View {
                                     Image(systemName: "photo")
                                         .font(.largeTitle)
                                         .foregroundColor(.secondary)
-                                    Text("Drop or select image")
+                                    Text("Drop, select, or paste image")
                                         .foregroundColor(.secondary)
                                 }
                             }
@@ -212,6 +212,10 @@ struct QRCodeToolView: View {
                     Label("Copy Result", systemImage: "doc.on.doc")
                 }
                 .disabled(decodedText.isEmpty)
+
+                Button(action: pasteImage) {
+                    Label("Paste Image", systemImage: "doc.on.clipboard")
+                }
 
                 Button(action: { showImporter = true }) {
                     Label("Select Image", systemImage: "photo.on.rectangle")
@@ -263,6 +267,14 @@ struct QRCodeToolView: View {
         let pasteboard = NSPasteboard.general
         pasteboard.clearContents()
         pasteboard.writeObjects([qrImage])
+    }
+
+    @MainActor
+    private func pasteImage() {
+        if let image = ClipboardService.shared.getImage() {
+            droppedImage = image
+            decodeQRCodeImage(image)
+        }
     }
 
     private func loadDroppedImage(from providers: [NSItemProvider]) -> Bool {

--- a/DevToolsTests/Core/Services/ClipboardServiceTests.swift
+++ b/DevToolsTests/Core/Services/ClipboardServiceTests.swift
@@ -104,12 +104,26 @@ final class ClipboardServiceTests: XCTestCase {
     func testGetURLWithInvalidString() {
         // Given
         clipboardService.copy("not a url")
-        
+
         // When
         let result = clipboardService.getURL()
-        
+
         // Then
         XCTAssertNil(result)
+    }
+
+    @MainActor
+    func testGetImage() {
+        // Given
+        let image = NSImage(size: NSSize(width: 1, height: 1))
+        NSPasteboard.general.clearContents()
+        NSPasteboard.general.writeObjects([image])
+
+        // When
+        let result = clipboardService.getImage()
+
+        // Then
+        XCTAssertNotNil(result)
     }
     
     // MARK: - Utility Tests


### PR DESCRIPTION
## Summary
- extend `ClipboardService` with a helper to read images from the pasteboard
- handle pasted images in `QRCodeTool` and update instructions
- add tests for new `getImage()` clipboard helper

## Testing
- `swift test --disable-testable-imports` *(fails: no tests found)*

------
https://chatgpt.com/codex/tasks/task_e_686821a344e4832b9fb3105657f5803b